### PR TITLE
feat: initial secret controller

### DIFF
--- a/internal/controller/const.go
+++ b/internal/controller/const.go
@@ -16,14 +16,9 @@ const (
 )
 
 // parseWatch checks if the object is being tracked
-// watch by default when no annotation is set
+// watch when annotation is empty or set to anything else except false
 func parseWatch(obj client.Object) bool {
-	watch := obj.GetAnnotations()[WatchAnnotation]
-	if watch == "" || watch == "true" {
-		return true
-	}
-
-	return false
+	return obj.GetAnnotations()[WatchAnnotation] != "false"
 }
 
 // parseKeysToWatch extracts keys to watch from the annotations
@@ -31,7 +26,7 @@ func parseWatch(obj client.Object) bool {
 func parseKeysToWatch(obj client.Object) []string {
 	keys := obj.GetAnnotations()[KeyWatchAnnotation]
 	if keys == "" {
-		return nil // Watch all keys
+		return nil
 	}
 
 	return strings.Split(keys, ",")

--- a/internal/controller/const.go
+++ b/internal/controller/const.go
@@ -1,9 +1,38 @@
 package controller
 
-const (
-	ConfigMapWatchAnnotation    string = "k8s-confsec-reloader.io/watch"
-	ConfigMapKeyWatchAnnotation string = "k8s-confsec-reloader.io/keys-to-watch"
-	ReloadTimestampAnnotation   string = "k8s-confsec-reloader.io/reload-timestamp"
+import (
+	"strings"
 
-	IndexKey string = "index.deployment.by.configmap"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const (
+	WatchAnnotation           string = "k8s-confsec-reloader.io/watch"
+	KeyWatchAnnotation        string = "k8s-confsec-reloader.io/keys-to-watch"
+	ReloadTimestampAnnotation string = "k8s-confsec-reloader.io/reload-timestamp"
+
+	ConfigMapIndexKey string = "index.deployment.by.configmap"
+	SecretIndexKey    string = "index.deployment.by.secret"
+)
+
+// parseWatch checks if the object is being tracked
+// watch by default when no annotation is set
+func parseWatch(obj client.Object) bool {
+	watch := obj.GetAnnotations()[WatchAnnotation]
+	if watch == "" || watch == "true" {
+		return true
+	}
+
+	return false
+}
+
+// parseKeysToWatch extracts keys to watch from the annotations
+// watch all keys by default when no annotation is set
+func parseKeysToWatch(obj client.Object) []string {
+	keys := obj.GetAnnotations()[KeyWatchAnnotation]
+	if keys == "" {
+		return nil // Watch all keys
+	}
+
+	return strings.Split(keys, ",")
+}

--- a/internal/controller/reload_resource.go
+++ b/internal/controller/reload_resource.go
@@ -1,0 +1,35 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TriggerDeploymentReload updates the Deployment's pod template to trigger a update
+func (r *ConfigMapReconciler) TriggerDeploymentReload(ctx context.Context, deployment *appsv1.Deployment) error {
+	patch := client.MergeFrom(deployment.DeepCopy())
+
+	if deployment.Spec.Template.Annotations == nil {
+		deployment.Spec.Template.Annotations = make(map[string]string)
+	}
+	deployment.Spec.Template.Annotations[ReloadTimestampAnnotation] = time.Now().Format(time.RFC3339)
+
+	// Use Patch instead of Update
+	return r.Patch(ctx, deployment, patch)
+}
+
+// TriggerDeploymentReload updates the Deployment's pod template to trigger a update
+func (r *SecretReconciler) TriggerDeploymentReload(ctx context.Context, deployment *appsv1.Deployment) error {
+	patch := client.MergeFrom(deployment.DeepCopy())
+
+	if deployment.Spec.Template.Annotations == nil {
+		deployment.Spec.Template.Annotations = make(map[string]string)
+	}
+	deployment.Spec.Template.Annotations[ReloadTimestampAnnotation] = time.Now().Format(time.RFC3339)
+
+	// Use Patch instead of Update
+	return r.Patch(ctx, deployment, patch)
+}

--- a/test.yaml
+++ b/test.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-config
   namespace: default
   annotations:
-    k8s-confsec-reloader.io/auto: "true"
+    k8s-confsec-reloader.io/watch: "true"
     k8s-confsec-reloader.io/keys-to-watch: "DATABASE_URL,API_KEY"
 data:
   DATABASE_URL: "postgres://localhost:5432/mydb"

--- a/test_secret.yaml
+++ b/test_secret.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: default
+  annotations:
+    k8s-confsec-reloader.io/watch: "true"
+    k8s-confsec-reloader.io/keys-to-watch: "DB_PASSWORD,API_SECRET"
+    k8s-confsec-reloader.io/do-nothng: "nothing_to_do"
+type: Opaque
+data:
+  DB_PASSWORD: "aTNUa1JibDBGc2hpdEhybzJlaDhBdw==" # base64 encoded "password123"
+  API_SECRET: "c3VwZXItc2VjcmV0LWtleQ==" # base64 encoded "super-secret-key"
+  UNUSED_SECRET: "dXNlbGVzcw==" # base64 encoded "useless"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app-secret
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app-secret
+  template:
+    metadata:
+      labels:
+        app: test-app-secret
+    spec:
+      containers:
+        - name: test-container
+          image: nginx
+          env:
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: my-secret
+                  key: DB_PASSWORD
+            - name: API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: my-secret
+                  key: API_SECRET
+          envFrom:
+            - secretRef:
+                name: my-secret


### PR DESCRIPTION
#### 📌 Initial Secret Controller Implementation

#### 🚀 Summary
This PR introduces the initial Secret controller with indexing and efficient tracking mechanisms for triggering Deployment reloads.

#### 🔹 Features Added
✅ Tracks all Secret updates, unless explicitly disabled via annotation (`k8s-confsec-reloader.io/watch: "false"`)
✅ Indexes Deployments by referenced Secrets to enable efficient lookups
✅ Triggers rolling updates of affected Deployments when watched Secret keys change
✅ Supports selective key tracking via annotation (`k8s-confsec-reloader.io/keys-to-watch`)
✅ Skips unnecessary reconciliations by comparing hashes of Secret data to detect changes in data