### PR TITLE
feat: namespace watch configuration

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,12 +29,14 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/BackAged/k8s-confsec-reloader/internal/config"
 	"github.com/BackAged/k8s-confsec-reloader/internal/controller"
 	// +kubebuilder:scaffold:imports
 )
@@ -118,6 +120,12 @@ func main() {
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 	}
 
+	watchNamespaces := config.GetConfigOrDie().Namespaces
+	defaultNamespaces := map[string]cache.Config{}
+	for _, v := range watchNamespaces {
+		defaultNamespaces[v] = cache.Config{}
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
@@ -136,6 +144,9 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
+		Cache: cache.Options{
+			DefaultNamespaces: defaultNamespaces,
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+type Config struct {
+	Namespaces []string
+}
+
+func GetConfigOrDie() *Config {
+	cfg := Config{}
+
+	ns, ok := os.LookupEnv("WATCH_NAMESPACE")
+	if ok {
+		cfg.Namespaces = strings.Split(ns, ",")
+	}
+
+	return &cfg
+}


### PR DESCRIPTION
#### 📌 Namespace watch configuration

#### 🚀 Summary
Namespace watch configuration through environment variable

#### 🔹 Features Added
✅ By default the controller watches all namespaces 
✅ To watch from only one namespace- set `WATCH_NAMESPACE="namespace"`
✅ To watch from multiple namespace- set `WATCH_NAMESPACE="namespace1, namespace2"`